### PR TITLE
Backoff retry with deadline

### DIFF
--- a/rhttpc-amqp-jdbc/src/main/scala/rhttpc/transport/amqpjdbc/AmqpJdbcPublisher.scala
+++ b/rhttpc-amqp-jdbc/src/main/scala/rhttpc/transport/amqpjdbc/AmqpJdbcPublisher.scala
@@ -28,7 +28,7 @@ private[amqpjdbc] class AmqpJdbcPublisher[PubMsg](underlying: Publisher[PubMsg],
 
   override def publish(msg: Message[PubMsg]): Future[Unit] = {
     msg match {
-      case delayed@DelayedMessage(content, delay, attempt) =>
+      case delayed@DelayedMessage(content, delay, attempt, date) =>
         scheduler.schedule(delayed, delay)
       case otherMessage =>
         underlying.publish(msg)

--- a/rhttpc-client/src/main/scala/rhttpc/client/config/ConfigParser.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/config/ConfigParser.scala
@@ -20,8 +20,7 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.ValueReader
-import rhttpc.client.proxy.{BackoffRetry, FailureResponseHandleStrategyChooser, HandleAll, SkipAll}
-
+import rhttpc.client.proxy.{BackoffRetry, BackoffRetryWithDeadline, FailureResponseHandleStrategyChooser, HandleAll, SkipAll}
 import scala.util.{Success, Try}
 
 object ConfigParser {
@@ -41,7 +40,10 @@ object RetryStrategyValueReader extends ValueReader[FailureResponseHandleStrateg
     config.as[Try[String]](path) match {
       case Success("handle-all") => HandleAll
       case Success("skip-all") => SkipAll
-      case _ => config.as[BackoffRetry](path)
+      case _ => config.as[Try[BackoffRetryWithDeadline]](path) match {
+        case Success(c) => c
+        case _ => config.as[BackoffRetry](path)
+      }
     }
   }
 }

--- a/rhttpc-client/src/main/scala/rhttpc/client/config/ConfigParser.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/config/ConfigParser.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.ValueReader
-import rhttpc.client.proxy.{BackoffRetry, BackoffRetryWithDeadline, FailureResponseHandleStrategyChooser, HandleAll, SkipAll}
+import rhttpc.client.proxy.{BackoffRetry, FailureResponseHandleStrategyChooser, HandleAll, SkipAll}
 import scala.util.{Success, Try}
 
 object ConfigParser {
@@ -40,10 +40,7 @@ object RetryStrategyValueReader extends ValueReader[FailureResponseHandleStrateg
     config.as[Try[String]](path) match {
       case Success("handle-all") => HandleAll
       case Success("skip-all") => SkipAll
-      case _ => config.as[Try[BackoffRetryWithDeadline]](path) match {
-        case Success(c) => c
-        case _ => config.as[BackoffRetry](path)
-      }
+      case _ => config.as[BackoffRetry](path)
     }
   }
 }

--- a/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
@@ -15,11 +15,11 @@
  */
 package rhttpc.client.protocol
 
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime}
 
 import scala.concurrent.duration.FiniteDuration
 
-case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: Option[FiniteDuration], receiveDate: LocalDateTime) {
+case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: Option[FiniteDuration], firstAttemptTimestamp: Instant) {
   def msg = correlated.msg
 
   def correlationId = correlated.correlationId
@@ -31,21 +31,21 @@ case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay
 }
 
 object Request {
-  def apply[T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: FiniteDuration, receiveDate: LocalDateTime): Request[T] = {
+  def apply[T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: FiniteDuration, firstAttemptTimestamp: Instant): Request[T] = {
     Request(
       correlated = correlated,
       attempt = attempt,
       lastPlannedDelay = Some(lastPlannedDelay),
-      receiveDate = receiveDate
+      firstAttemptTimestamp = firstAttemptTimestamp
     )
   }
 
-  def firstAttempt[T](correlated: Correlated[T]): Request[T] = {
+  def firstAttempt[T](correlated: Correlated[T], firstAttemptTime: Instant): Request[T] = {
     Request(
       correlated = correlated,
       attempt = 1,
       lastPlannedDelay = None,
-      receiveDate = LocalDateTime.now
+      firstAttemptTimestamp = firstAttemptTime
     )
   }
 }

--- a/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
@@ -31,12 +31,12 @@ case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay
 }
 
 object Request {
-  def apply[T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: FiniteDuration): Request[T] = {
+  def apply[T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: FiniteDuration, receiveDate: LocalDateTime): Request[T] = {
     Request(
       correlated = correlated,
       attempt = attempt,
       lastPlannedDelay = Some(lastPlannedDelay),
-      receiveDate = LocalDateTime.now
+      receiveDate = receiveDate
     )
   }
 

--- a/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/protocol/Request.scala
@@ -15,9 +15,11 @@
  */
 package rhttpc.client.protocol
 
+import java.time.LocalDateTime
+
 import scala.concurrent.duration.FiniteDuration
 
-case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: Option[FiniteDuration]) {
+case class Request[+T](correlated: Correlated[T], attempt: Int, lastPlannedDelay: Option[FiniteDuration], receiveDate: LocalDateTime) {
   def msg = correlated.msg
 
   def correlationId = correlated.correlationId
@@ -33,7 +35,8 @@ object Request {
     Request(
       correlated = correlated,
       attempt = attempt,
-      lastPlannedDelay = Some(lastPlannedDelay)
+      lastPlannedDelay = Some(lastPlannedDelay),
+      receiveDate = LocalDateTime.now
     )
   }
 
@@ -41,7 +44,8 @@ object Request {
     Request(
       correlated = correlated,
       attempt = 1,
-      lastPlannedDelay = None
+      lastPlannedDelay = None,
+      receiveDate = LocalDateTime.now
     )
   }
 }

--- a/rhttpc-client/src/main/scala/rhttpc/client/proxy/FailureResponseHandleStrategyChooser.scala
+++ b/rhttpc-client/src/main/scala/rhttpc/client/proxy/FailureResponseHandleStrategyChooser.scala
@@ -18,7 +18,7 @@ package rhttpc.client.proxy
 import scala.concurrent.duration._
 
 trait FailureResponseHandleStrategyChooser {
-  def choose(attemptsSoFar: Int, lastPlannedDelay: Option[FiniteDuration]): ResponseHandleStrategy
+  def choose(attemptsSoFar: Int, lastPlannedDelay: Option[FiniteDuration], ): ResponseHandleStrategy
 }
 
 sealed trait ResponseHandleStrategy
@@ -52,5 +52,14 @@ case class BackoffRetry(initialDelay: FiniteDuration, multiplier: BigDecimal, ma
       }
       Retry(nextDelay)
     }
+  }
+}
+
+case class BackoffRetryWithDeadline(override val initialDelay: FiniteDuration,
+                                    override val multiplier: BigDecimal,
+                                    override val maxRetries: Int,
+                                    deadline: FiniteDuration) extends BackoffRetry(initialDelay, multiplier, maxRetries) {
+  override def choose(attemptsSoFar: Int, lastPlannedDelay: Option[FiniteDuration]): ResponseHandleStrategy = {
+    if ()
   }
 }

--- a/rhttpc-client/src/test/scala/rhttpc/client/config/ConfigParserSpec.scala
+++ b/rhttpc-client/src/test/scala/rhttpc/client/config/ConfigParserSpec.scala
@@ -17,7 +17,7 @@ package rhttpc.client.config
 
 import com._
 import org.scalatest.{FlatSpec, Matchers}
-import rhttpc.client.proxy.{BackoffRetry, HandleAll}
+import rhttpc.client.proxy.{BackoffRetry, BackoffRetryWithDeadline, HandleAll}
 
 import scala.concurrent.duration._
 
@@ -53,4 +53,21 @@ class ConfigParserSpec extends FlatSpec with Matchers {
     ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, HandleAll)
   }
 
+  it should "parse config with backoff with deadline strategy" in {
+    val config = typesafe.config.ConfigFactory.parseString(
+      """x {
+        |  queuesPrefix = "rhttpc"
+        |  batchSize = 10
+        |  parallelConsumers = 1
+        |  retryStrategy {
+        |    initialDelay = 5 seconds
+        |    multiplier = 1.2
+        |    maxRetries = 3
+        |    deadline = 5 seconds
+        |  }
+        |}
+      """.stripMargin)
+
+    ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, BackoffRetryWithDeadline(5 seconds, 1.2, 3, 5 seconds))
+  }
 }

--- a/rhttpc-client/src/test/scala/rhttpc/client/config/ConfigParserSpec.scala
+++ b/rhttpc-client/src/test/scala/rhttpc/client/config/ConfigParserSpec.scala
@@ -17,7 +17,7 @@ package rhttpc.client.config
 
 import com._
 import org.scalatest.{FlatSpec, Matchers}
-import rhttpc.client.proxy.{BackoffRetry, BackoffRetryWithDeadline, HandleAll}
+import rhttpc.client.proxy.{BackoffRetry, HandleAll}
 
 import scala.concurrent.duration._
 
@@ -37,7 +37,7 @@ class ConfigParserSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin)
 
-    ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, BackoffRetry(5.seconds, 1.2, 3))
+    ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, BackoffRetry(5.seconds, 1.2, 3, None))
   }
 
   it should "parse config with publish all strategy" in {
@@ -68,6 +68,6 @@ class ConfigParserSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin)
 
-    ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, BackoffRetryWithDeadline(5 seconds, 1.2, 3, 5 seconds))
+    ConfigParser.parse(config, "x") shouldEqual RhttpcConfig("rhttpc", 10, 1, BackoffRetry(5 seconds, 1.2, 3, Some(5 seconds)))
   }
 }

--- a/rhttpc-inmem/src/main/scala/rhttpc/transport/inmem/InMemPublisher.scala
+++ b/rhttpc-inmem/src/main/scala/rhttpc/transport/inmem/InMemPublisher.scala
@@ -27,7 +27,7 @@ private[inmem] class InMemPublisher[Msg](queueActor: ActorRef)
 
   override def publish(msg: Message[Msg]): Future[Unit] = {
     msg match {
-      case delayed@DelayedMessage(_, delay, _) =>
+      case delayed@DelayedMessage(_, delay, _, _) =>
         system.scheduler.scheduleOnce(delay, queueActor, delayed)
       case _ =>
         queueActor ! msg

--- a/rhttpc-transport/src/main/scala/rhttpc/transport/Message.scala
+++ b/rhttpc-transport/src/main/scala/rhttpc/transport/Message.scala
@@ -15,26 +15,30 @@
  */
 package rhttpc.transport
 
+import java.time.LocalDateTime
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 case class Message[+T](content: T, properties: Map[String, Any] = Map.empty)
 
 object DelayedMessage {
-  def apply[T](content: T, delay: FiniteDuration, attempt: Int): Message[T] = {
+  def apply[T](content: T, delay: FiniteDuration, attempt: Int, receiveDate: LocalDateTime): Message[T] = {
     val props = Map(
       MessagePropertiesNaming.delayProperty -> delay.toMillis,
-      MessagePropertiesNaming.attemptProperty -> attempt.toLong
+      MessagePropertiesNaming.attemptProperty -> attempt.toLong,
+      MessagePropertiesNaming.receiveDateProperty -> receiveDate.toString
     )
     Message(content, properties = props)
   }
 
-  def unapply[T](message: Message[T]): Option[(T, FiniteDuration, Int)] = {
+  def unapply[T](message: Message[T]): Option[(T, FiniteDuration, Int, LocalDateTime)] = {
     Option(message).collect {
       case Message(content, props) if props.contains(MessagePropertiesNaming.delayProperty) =>
         val delay = props(MessagePropertiesNaming.delayProperty).asInstanceOf[Number].longValue() millis
         val attempt = props.get(MessagePropertiesNaming.attemptProperty).map(_.asInstanceOf[Number].intValue()).getOrElse(1)
-        (content, delay, attempt)
+        val date = props.get(MessagePropertiesNaming.receiveDateProperty).map(_.asInstanceOf[String]).map(LocalDateTime.parse).getOrElse(LocalDateTime.now())
+        (content, delay, attempt, date)
     }
   }
 }

--- a/rhttpc-transport/src/main/scala/rhttpc/transport/Message.scala
+++ b/rhttpc-transport/src/main/scala/rhttpc/transport/Message.scala
@@ -15,29 +15,29 @@
  */
 package rhttpc.transport
 
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime}
 
 import scala.concurrent.duration._
 
 case class Message[+T](content: T, properties: Map[String, Any] = Map.empty)
 
 object DelayedMessage {
-  def apply[T](content: T, delay: FiniteDuration, attempt: Int, receiveDate: LocalDateTime): Message[T] = {
+  def apply[T](content: T, delay: FiniteDuration, attempt: Int, firstAttemptTimestamp: Instant): Message[T] = {
     val props = Map(
       MessagePropertiesNaming.delayProperty -> delay.toMillis,
       MessagePropertiesNaming.attemptProperty -> attempt.toLong,
-      MessagePropertiesNaming.receiveDateProperty -> receiveDate.toString
+      MessagePropertiesNaming.receiveDateProperty -> firstAttemptTimestamp.toString
     )
     Message(content, properties = props)
   }
 
-  def unapply[T](message: Message[T]): Option[(T, FiniteDuration, Int, LocalDateTime)] = {
+  def unapply[T](message: Message[T]): Option[(T, FiniteDuration, Int, Instant)] = {
     Option(message).collect {
       case Message(content, props) if props.contains(MessagePropertiesNaming.delayProperty) =>
         val delay = props(MessagePropertiesNaming.delayProperty).asInstanceOf[Number].longValue() millis
         val attempt = props.get(MessagePropertiesNaming.attemptProperty).map(_.asInstanceOf[Number].intValue()).getOrElse(1)
-        val date = props.get(MessagePropertiesNaming.receiveDateProperty).map(_.asInstanceOf[String]).map(LocalDateTime.parse).getOrElse(LocalDateTime.now())
-        (content, delay, attempt, date)
+        val firstAttemptTimestamp = props.get(MessagePropertiesNaming.receiveDateProperty).map(_.asInstanceOf[String]).map(Instant.parse).getOrElse(Instant.now())
+        (content, delay, attempt, firstAttemptTimestamp)
     }
   }
 }

--- a/rhttpc-transport/src/main/scala/rhttpc/transport/MessagePropertiesNaming.scala
+++ b/rhttpc-transport/src/main/scala/rhttpc/transport/MessagePropertiesNaming.scala
@@ -21,6 +21,8 @@ object MessagePropertiesNaming {
 
   def attemptProperty = transportProperty("attempt")
 
+  def receiveDateProperty = transportProperty("receive-date")
+
   def transportProperty(name: String): String = "x-" + name
 
 }

--- a/rhttpc-transport/src/test/scala/rhttpc/transport/DelayedMessageSpec.scala
+++ b/rhttpc-transport/src/test/scala/rhttpc/transport/DelayedMessageSpec.scala
@@ -23,9 +23,9 @@ import scala.language.postfixOps
 class DelayedMessageSpec extends FlatSpec with Matchers {
 
   it should "extract delayed message from properties in various numeric format" in {
-    val DelayedMessage(_, fromLongDuration, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100L))
+    val DelayedMessage(_, fromLongDuration, _, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100L))
     fromLongDuration shouldEqual (100 millis)
-    val DelayedMessage(_, fromIntDuration, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100))
+    val DelayedMessage(_, fromIntDuration, _, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100))
     fromIntDuration shouldEqual (100 millis)
   }
 

--- a/rhttpc-transport/src/test/scala/rhttpc/transport/DelayedMessageSpec.scala
+++ b/rhttpc-transport/src/test/scala/rhttpc/transport/DelayedMessageSpec.scala
@@ -22,7 +22,7 @@ import scala.language.postfixOps
 
 class DelayedMessageSpec extends FlatSpec with Matchers {
 
-  it should "extract delayed message from properties in various numeric format" in {
+  it should "extract delayed message from properties in various numeric formats" in {
     val DelayedMessage(_, fromLongDuration, _, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100L))
     fromLongDuration shouldEqual (100 millis)
     val DelayedMessage(_, fromIntDuration, _, _) = Message("fooMsg", Map(MessagePropertiesNaming.delayProperty -> 100))


### PR DESCRIPTION
Implemented a new strategy similar to backoff. 
Basically what it does is allow you to repeat requests until a specific deadline.
For example you might want in your application to perform some kind of operation which is repeated on failure but has a cut off after 24 hours. 

One could get a similar behaviour using only the backoff strategy which already exists (setting max retries to 24 and interval to 1 hour) but if your application would be down for example for an hour or a day then retries could still be going after bringing it back.